### PR TITLE
chore: Add failing test for after action transaction bug.

### DIFF
--- a/test/support/changes/failing_after_action_change.ex
+++ b/test/support/changes/failing_after_action_change.ex
@@ -1,0 +1,11 @@
+defmodule AshSqlite.Test.FailingAfterActionChange do
+  @moduledoc false
+  use Ash.Resource.Change
+
+  def change(changeset, _, _) do
+    changeset
+    |> Ash.Changeset.after_action(fn _changeset, _record ->
+      {:error, "Things could always be better"}
+    end)
+  end
+end

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -60,6 +60,10 @@ defmodule AshSqlite.Test.Post do
       argument(:amount, :integer, default: 1)
       change(atomic_update(:score, expr((score || 0) + ^arg(:amount))))
     end
+
+    create :failing_after_action do
+      change(AshSqlite.Test.FailingAfterActionChange)
+    end
   end
 
   identities do

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -1,0 +1,19 @@
+defmodule AshSqlite.Test.TransactionTest do
+  @moduledoc false
+  use AshSqlite.RepoCase, async: false
+
+  test "when an after action hook fails, it rolls back the transaction" do
+    assert [] =
+             AshSqlite.Test.Post
+             |> AshSqlite.TestRepo.all()
+
+    assert {:error, _} =
+             AshSqlite.Test.Post
+             |> Ash.Changeset.for_create(:failing_after_action, %{title: "turtle the title"})
+             |> Ash.create()
+
+    assert [] =
+             AshSqlite.Test.Post
+             |> AshSqlite.TestRepo.all()
+  end
+end


### PR DESCRIPTION
After action hooks failing are not rolling back transactions.