### PR TITLE
Removing a postgresql specific configuration from `ash_sqlite.install`

### DIFF
--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -357,8 +357,8 @@ defmodule AshSqlite.DataLayer do
             end
         end
 
-      Mix.Task.run("ash_postgres.rollback", args ++ ["-r", inspect(repo), "-n", to_string(n)])
-      Mix.Task.reenable("ash_postgres.rollback")
+      Mix.Task.run("ash_sqlite.rollback", args ++ ["-r", inspect(repo), "-n", to_string(n)])
+      Mix.Task.reenable("ash_sqlite.rollback")
     end
   end
 

--- a/lib/mix/tasks/ash_sqlite.install.ex
+++ b/lib/mix/tasks/ash_sqlite.install.ex
@@ -107,15 +107,7 @@ defmodule Mix.Tasks.AshSqlite.Install do
     import Config
 
     if config_env() == :prod do
-      database_url =
-        System.get_env("DATABASE_URL") ||
-          raise \"\"\"
-          environment variable DATABASE_URL is missing.
-          For example: ecto://USER:PASS@HOST/DATABASE
-          \"\"\"
-
       config #{inspect(otp_app)}, #{inspect(repo)},
-        url: database_url,
         pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10")
     end
     """
@@ -142,63 +134,20 @@ defmodule Mix.Tasks.AshSqlite.Install do
         |> Igniter.Code.Common.move_to_cursor_match_in_scope(patterns)
         |> case do
           {:ok, zipper} ->
-            case Igniter.Code.Function.move_to_function_call_in_current_scope(
-                   zipper,
-                   :=,
-                   2,
-                   fn call ->
-                     Igniter.Code.Function.argument_matches_pattern?(
-                       call,
-                       0,
-                       {:database_url, _, ctx} when is_atom(ctx)
-                     )
-                   end
-                 ) do
-              {:ok, _zipper} ->
-                zipper
-                |> Igniter.Project.Config.modify_configuration_code(
-                  [repo, :url],
-                  otp_app,
-                  {:database_url, [], nil}
-                )
-                |> Igniter.Project.Config.modify_configuration_code(
-                  [repo, :pool_size],
-                  otp_app,
-                  Sourceror.parse_string!("""
-                  String.to_integer(System.get_env("POOL_SIZE") || "10")
-                  """)
-                )
-                |> then(&{:ok, &1})
+            zipper
+            |> Igniter.Project.Config.modify_configuration_code(
+              [repo, :pool_size],
+              otp_app,
+              Sourceror.parse_string!("""
+              String.to_integer(System.get_env("POOL_SIZE") || "10")
+              """)
+            )
+            |> then(&{:ok, &1})
 
-              _ ->
-                Igniter.Code.Common.add_code(zipper, """
-                  database_url =
-                    System.get_env("DATABASE_URL") ||
-                      raise \"\"\"
-                      environment variable DATABASE_URL is missing.
-                      For example: ecto://USER:PASS@HOST/DATABASE
-                      \"\"\"
-
-                  config #{inspect(otp_app)}, Helpdesk.Repo,
-                    url: database_url,
-                    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10")
-                """)
-            end
-
-          :error ->
+          _ ->
             Igniter.Code.Common.add_code(zipper, """
-            if config_env() == :prod do
-              database_url =
-                System.get_env("DATABASE_URL") ||
-                  raise \"\"\"
-                  environment variable DATABASE_URL is missing.
-                  For example: ecto://USER:PASS@HOST/DATABASE
-                  \"\"\"
-
               config #{inspect(otp_app)}, Helpdesk.Repo,
-                url: database_url,
                 pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10")
-            end
             """)
         end
       end

--- a/lib/mix/tasks/ash_sqlite.install.ex
+++ b/lib/mix/tasks/ash_sqlite.install.ex
@@ -213,7 +213,6 @@ defmodule Mix.Tasks.AshSqlite.Install do
       [repo, :database],
       "../path/to/your.db"
     )
-    |> Igniter.Project.Config.configure_new("dev.exs", otp_app, [repo, :port], 5432)
     |> Igniter.Project.Config.configure_new(
       "dev.exs",
       otp_app,


### PR DESCRIPTION
Not really sure how to test this except:

`mix igniter.new igniter_ash_phoenix_sqlite_remove_p_port_configuring --install ash,ash_phoenix,ash_sqlite@github:djgoku/ash_sqlite@chore-remove-setting-repo-port --with phx.new --with-args="--database sqlite3"` I have also attached the log below.

[removing-more-postgresql-log.txt](https://github.com/user-attachments/files/17788315/removing-more-postgresql-log.txt)

Just a thought, but if I am installing `ash_phoenix` and `ash_sqlite` could we just add an implicit `--with-args="--database sqlite3"` since if you don't you'll have a few bits of postgresql to remove since phx.new defaults to installing for postgresql. Not really sure how to solve this, but was just thinking about it.
