### PR TITLE
feat: strict table support

### DIFF
--- a/documentation/dsls/DSL-AshSqlite.DataLayer.md
+++ b/documentation/dsls/DSL-AshSqlite.DataLayer.md
@@ -48,6 +48,7 @@ end
 | [`migration_ignore_attributes`](#sqlite-migration_ignore_attributes){: #sqlite-migration_ignore_attributes } | `list(atom)` | `[]` | A list of attributes that will be ignored when generating migrations. |
 | [`table`](#sqlite-table){: #sqlite-table } | `String.t` |  | The table to store and read the resource from. If this is changed, the migration generator will not remove the old table. |
 | [`polymorphic?`](#sqlite-polymorphic?){: #sqlite-polymorphic? } | `boolean` | `false` | Declares this resource as polymorphic. See the [polymorphic resources guide](/documentation/topics/resources/polymorphic-resources.md) for more. |
+| [`strict?`](#sqlite-strict?){: #sqlite-strict? } | `boolean` | `false` | Whether the migration generator should create a [strict table](https://www.sqlite.org/stricttables.html), which enforces types more strictly. |
 
 
 ### sqlite.custom_indexes

--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -278,6 +278,13 @@ defmodule AshSqlite.DataLayer do
         doc: """
         Declares this resource as polymorphic. See the [polymorphic resources guide](/documentation/topics/resources/polymorphic-resources.md) for more.
         """
+      ],
+      strict?: [
+        type: :boolean,
+        default: false,
+        doc: """
+        Whether the migration generator should create a [strict table](https://www.sqlite.org/stricttables.html), which enforces types more strictly.
+        """
       ]
     ]
   }

--- a/lib/data_layer/info.ex
+++ b/lib/data_layer/info.ex
@@ -114,4 +114,9 @@ defmodule AshSqlite.DataLayer.Info do
   def skip_unique_indexes(resource) do
     Extension.get_opt(resource, [:sqlite], :skip_unique_indexes, [])
   end
+
+  @doc "Whether the migration generator should create a strict table"
+  def strict?(resource) do
+    Extension.get_opt(resource, [:sqlite], :strict?, false)
+  end
 end

--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -1103,7 +1103,8 @@ defmodule AshSqlite.MigrationGenerator do
 
   defp group_into_phases(
          [
-           %Operation.CreateTable{table: table, multitenancy: multitenancy} | rest
+           %Operation.CreateTable{table: table, options: options, multitenancy: multitenancy}
+           | rest
          ],
          nil,
          acc
@@ -1120,6 +1121,7 @@ defmodule AshSqlite.MigrationGenerator do
       %Phase.Create{
         table: table,
         multitenancy: multitenancy,
+        options: options,
         operations: has_to_be_in_this_phase
       },
       acc
@@ -1543,7 +1545,8 @@ defmodule AshSqlite.MigrationGenerator do
       %Operation.CreateTable{
         table: snapshot.table,
         multitenancy: snapshot.multitenancy,
-        old_multitenancy: empty_snapshot.multitenancy
+        old_multitenancy: empty_snapshot.multitenancy,
+        options: [strict?: snapshot.strict?]
       }
       | acc
     ])
@@ -2204,7 +2207,8 @@ defmodule AshSqlite.MigrationGenerator do
       repo: AshSqlite.DataLayer.Info.repo(resource),
       multitenancy: multitenancy(resource),
       base_filter: AshSqlite.DataLayer.Info.base_filter_sql(resource),
-      has_create_action: has_create_action?(resource)
+      has_create_action: has_create_action?(resource),
+      strict?: AshSqlite.DataLayer.Info.strict?(resource)
     }
 
     hash =

--- a/lib/migration_generator/operation.ex
+++ b/lib/migration_generator/operation.ex
@@ -67,7 +67,7 @@ defmodule AshSqlite.MigrationGenerator.Operation do
 
   defmodule CreateTable do
     @moduledoc false
-    defstruct [:table, :multitenancy, :old_multitenancy]
+    defstruct [:table, :multitenancy, :old_multitenancy, options: []]
   end
 
   defmodule AddAttribute do

--- a/lib/migration_generator/phase.ex
+++ b/lib/migration_generator/phase.ex
@@ -3,12 +3,17 @@ defmodule AshSqlite.MigrationGenerator.Phase do
 
   defmodule Create do
     @moduledoc false
-    defstruct [:table, :multitenancy, operations: [], commented?: false]
+    defstruct [:table, :multitenancy, operations: [], options: [], commented?: false]
 
     import AshSqlite.MigrationGenerator.Operation.Helper, only: [as_atom: 1]
 
-    def up(%{table: table, operations: operations}) do
-      opts = ""
+    def up(%{table: table, operations: operations, options: options}) do
+      opts =
+        if options[:strict?] do
+          ~s', options: "STRICT"'
+        else
+          ""
+        end
 
       "create table(:#{as_atom(table)}, primary_key: false#{opts}) do\n" <>
         Enum.map_join(operations, "\n", fn operation -> operation.__struct__.up(operation) end) <>


### PR DESCRIPTION
Closes #142

Add option in the DSL to generate [strict table](https://www.sqlite.org/stricttables.html), which enforces types more strictly (default is false).

Ecto already supports custom options that will be appended after the generated create table statement https://hexdocs.pm/ecto_sql/Ecto.Migration.html#table/2-options

### Contributor checklist

- [x] Features include unit/acceptance tests
