### PR TITLE
Fixed generate_migrations --dev duplicating migration files

### DIFF
--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -2006,25 +2006,13 @@ defmodule AshSqlite.MigrationGenerator do
       snapshot_folder
       |> File.ls!()
       |> Enum.filter(&String.ends_with?(&1, ".json"))
-      |> Enum.map(&String.trim_trailing(&1, ".json"))
-      |> Enum.map(&Integer.parse/1)
-      |> Enum.filter(fn
-        {_int, remaining} ->
-          remaining == ""
-
-        :error ->
-          false
-      end)
-      |> Enum.map(&elem(&1, 0))
       |> case do
         [] ->
           get_old_snapshot(folder, snapshot)
 
-        timestamps ->
-          timestamp = Enum.max(timestamps)
-          snapshot_file = Path.join(snapshot_folder, "#{timestamp}.json")
-
-          snapshot_file
+        snapshot_files ->
+          snapshot_folder
+          |> Path.join(Enum.max(snapshot_files))
           |> File.read!()
           |> load_snapshot()
       end


### PR DESCRIPTION
This issue was due to `get_existing_snapshot` ignoring dev migrations because they don't comform to `{timestamp.json}`.

I fixed by making it closer to its postgres counterpart: not trying to parse the timestamp and instead comparing the filenames, which works the same until timestamps change their numbers of digits.


I'll think about how to introduce some reuse, because postgres has the same feature except its getting more love.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
