### PR TITLE
Expected this to not leave any records behind when action failed

### DIFF
--- a/test/bulk_create_test.exs
+++ b/test/bulk_create_test.exs
@@ -140,4 +140,21 @@ defmodule AshSqlite.BulkCreateTest do
                |> Ash.read!()
     end
   end
+
+  describe "transaction errors" do
+    @tag this: "this"
+    test "transaction errors rolls back" do
+      org =
+        AshSqlite.Test.Organization
+        |> Ash.Changeset.for_create(:create, %{name: "foo"})
+        |> Ash.create!()
+
+
+      assert {:error, _} = AshSqlite.Test.Post
+      |> Ash.Changeset.for_create(:create_with_failing_change, %{organization_id: org.id, title: "foo"})
+      |> Ash.create()
+
+      assert {:ok, []} = Ash.read(AshSqlite.Test.Post)
+    end
+  end
 end

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -64,6 +64,12 @@ defmodule AshSqlite.Test.Post do
     destroy :destroy_only_freds do
       change(filter(expr(title == "fred")))
     end
+
+    create :create_with_failing_change do
+      change after_action(fn _cs, _post, _ctx ->
+          {:error, field: :org, message: "Failing action"}
+        end)
+    end
   end
 
   identities do


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
