### PR TITLE
Fix missing case in to_ecto

### DIFF
--- a/lib/repo.ex
+++ b/lib/repo.ex
@@ -133,6 +133,10 @@ defmodule AshSqlite.Repo do
         Enum.map(value, &to_ecto/1)
       end
 
+      def to_ecto(%Ecto.Changeset{} = changeset) do
+        Map.put(changeset, :data, to_ecto(changeset.data))
+      end
+
       def to_ecto(%resource{} = record) do
         if Spark.Dsl.is?(resource, Ash.Resource) do
           resource


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies


---

This took me many hours to track down. It looks like the ash_sqlite is missing this case, which is included in ash_postgres.
Without this case, I've had many weird issues when using standard ecto functions on ash resources.
Including this case fixes all of these issue.
Sorry for the vague issue description, but I've got 100s of unit tests which all failed in mysterious ways until I tracked it down to this missing clause..