### PR TITLE
Use SQLite IN for large scalar list filters

### DIFF
--- a/lib/sql_implementation.ex
+++ b/lib/sql_implementation.ex
@@ -24,6 +24,52 @@ defmodule AshSqlite.SqlImplementation do
   @impl true
   def expr(
         query,
+        %Ash.Query.Operator.In{
+          right: %Ash.Query.Function.Type{arguments: [right | _]}
+        } = op,
+        bindings,
+        embedded?,
+        acc,
+        type
+      )
+      when is_list(right) or is_struct(right, MapSet) do
+    expr(query, %{op | right: right}, bindings, embedded?, acc, type)
+  end
+
+  def expr(
+        query,
+        %Ash.Query.Operator.In{left: left, right: right, embedded?: pred_embedded?},
+        bindings,
+        embedded?,
+        acc,
+        _type
+      )
+      when is_list(right) or is_struct(right, MapSet) do
+    {item_type, constraints} = in_item_type(left)
+    context_embedded? = pred_embedded? || embedded?
+    values = Enum.to_list(right)
+
+    if Enum.any?(values, &complex_in_value?/1) do
+      expand_in_to_or(query, left, values, bindings, context_embedded?, acc, item_type)
+    else
+      {left_expr, acc} =
+        AshSql.Expr.dynamic_expr(
+          query,
+          left,
+          in_left_bindings(bindings, item_type, constraints),
+          context_embedded?,
+          in_left_type(item_type, constraints),
+          acc
+        )
+
+      values = dump_in_values(query, bindings, values, item_type, constraints)
+
+      {:ok, Ecto.Query.dynamic(^left_expr in ^values), acc}
+    end
+  end
+
+  def expr(
+        query,
         %like{arguments: [arg1, arg2], embedded?: pred_embedded?},
         bindings,
         embedded?,
@@ -49,49 +95,6 @@ defmodule AshSqlite.SqlImplementation do
     else
       {:ok, Ecto.Query.dynamic(type(^inner_dyn, ^type)), acc}
     end
-  end
-
-  def expr(
-        query,
-        %Ash.Query.Operator.In{
-          right: %Ash.Query.Function.Type{arguments: [right | _]} = type
-        } = op,
-        bindings,
-        embedded?,
-        acc,
-        type
-      )
-      when is_list(right) or is_struct(right, MapSet) do
-    expr(query, %{op | right: right}, bindings, embedded?, acc, type)
-  end
-
-  def expr(
-        query,
-        %Ash.Query.Operator.In{left: left, right: right, embedded?: pred_embedded?},
-        bindings,
-        embedded?,
-        acc,
-        type
-      )
-      when is_list(right) or is_struct(right, MapSet) do
-    right
-    |> Enum.reduce(nil, fn val, acc ->
-      if is_nil(acc) do
-        %Ash.Query.Operator.Eq{left: left, right: val}
-      else
-        %Ash.Query.BooleanExpression{
-          op: :or,
-          left: acc,
-          right: %Ash.Query.Operator.Eq{left: left, right: val}
-        }
-      end
-    end)
-    |> then(fn expr ->
-      {expr, acc} =
-        AshSql.Expr.dynamic_expr(query, expr, bindings, pred_embedded? || embedded?, type, acc)
-
-      {:ok, expr, acc}
-    end)
   end
 
   def expr(
@@ -288,6 +291,120 @@ defmodule AshSqlite.SqlImplementation do
 
   defp plain_map?(value) when is_map(value) and not is_struct(value), do: true
   defp plain_map?(_), do: false
+
+  defp in_item_type(%Ash.Query.Ref{attribute: %{type: type} = attribute}) do
+    {type, Map.get(attribute, :constraints, []) || []}
+  end
+
+  defp in_item_type(_), do: {nil, []}
+
+  defp in_left_bindings(bindings, item_type, constraints) do
+    if ci_string_type?(item_type, constraints) do
+      bindings
+    else
+      Map.put(bindings, :no_cast?, true)
+    end
+  end
+
+  defp in_left_type(item_type, constraints) do
+    if ci_string_type?(item_type, constraints) do
+      if constraints == [] do
+        item_type
+      else
+        {item_type, constraints}
+      end
+    end
+  end
+
+  defp complex_in_value?(value) do
+    Ash.Expr.expr?(value) || is_list(value) || (is_map(value) && !is_struct(value))
+  end
+
+  defp expand_in_to_or(query, left, values, bindings, embedded?, acc, type) do
+    values
+    |> Enum.reduce(nil, fn value, acc ->
+      if is_nil(acc) do
+        %Ash.Query.Operator.Eq{left: left, right: value}
+      else
+        %Ash.Query.BooleanExpression{
+          op: :or,
+          left: acc,
+          right: %Ash.Query.Operator.Eq{left: left, right: value}
+        }
+      end
+    end)
+    |> then(fn expr ->
+      {expr, acc} = AshSql.Expr.dynamic_expr(query, expr, bindings, embedded?, type, acc)
+      {:ok, expr, acc}
+    end)
+  end
+
+  defp dump_in_values(_query, _bindings, values, nil, _constraints) do
+    Enum.map(values, fn
+      # Preserve the old equality fallback for untyped atom values when the LHS has no attribute.
+      value when is_atom(value) and not is_boolean(value) and not is_nil(value) ->
+        to_string(value)
+
+      value ->
+        value
+    end)
+  end
+
+  defp dump_in_values(query, bindings, values, item_type, constraints) do
+    ecto_type =
+      parameterized_type(item_type, constraints) ||
+        item_type
+        |> Ash.Type.get_type()
+        |> Ash.Type.storage_type(constraints)
+
+    adapter = sqlite_adapter!(query, bindings)
+
+    Enum.map(values, fn value ->
+      case Ecto.Type.adapter_dump(adapter, ecto_type, value) do
+        {:ok, value} -> value
+        # Some custom/already-dumped values may not accept another dump; keep the old value.
+        _ -> value
+      end
+    end)
+  end
+
+  defp sqlite_adapter!(query, bindings) do
+    repo =
+      bindings
+      |> Map.fetch!(:resource)
+      |> AshSql.dynamic_repo(__MODULE__, query)
+
+    case repo.__adapter__() do
+      Ecto.Adapters.SQLite3 ->
+        Ecto.Adapters.SQLite3
+
+      adapter ->
+        raise ArgumentError,
+              "expected #{inspect(repo)} to use sqlite adapter `Ecto.Adapters.SQLite3`, got: #{inspect(adapter)}"
+    end
+  end
+
+  defp ci_string_type?({:parameterized, {inner_type, constraints}}, []) do
+    parameterized_ci_string_type?(inner_type, constraints)
+  end
+
+  defp ci_string_type?({:parameterized, inner_type, constraints}, []) do
+    parameterized_ci_string_type?(inner_type, constraints)
+  end
+
+  defp ci_string_type?(type, constraints) when is_atom(type) do
+    type = Ash.Type.get_type(type)
+    Ash.Type.ash_type?(type) && Ash.Type.storage_type(type, constraints) == :ci_string
+  end
+
+  defp ci_string_type?(_, _), do: false
+
+  defp parameterized_ci_string_type?(inner_type, constraints)
+       when is_atom(inner_type) and is_list(constraints) do
+    function_exported?(inner_type, :type, 1) && inner_type.type(constraints) == :ci_string
+  end
+
+  defp parameterized_ci_string_type?(_, _), do: false
 
   @impl true
   def type_expr(expr, nil), do: expr

--- a/test/filter_test.exs
+++ b/test/filter_test.exs
@@ -4,7 +4,7 @@
 
 defmodule AshSqlite.FilterTest do
   use AshSqlite.RepoCase, async: false
-  alias AshSqlite.Test.{Author, Comment, Post}
+  alias AshSqlite.Test.{Author, Comment, IntegerPost, Post}
 
   require Ash.Query
 
@@ -181,6 +181,134 @@ defmodule AshSqlite.FilterTest do
                Post
                |> Ash.Query.filter(title in ["title1", "title2"])
                |> Ash.Query.sort(title: :asc)
+               |> Ash.read!()
+    end
+
+    test "large pinned lists do not compile to nested OR expressions" do
+      titles = Enum.map(1..1100, &"title#{&1}")
+
+      query =
+        Post
+        |> Ash.Query.new()
+        |> Ash.Query.filter(title in ^titles)
+
+      {:ok, ecto_query} = Ash.Query.data_layer_query(query)
+      {sql, _params} = Ecto.Adapters.SQL.to_sql(:all, TestRepo, ecto_query)
+
+      assert sql =~ " IN "
+      assert sql =~ ~s(p0."title" IN)
+      refute sql =~ " OR "
+      refute sql =~ ~S|CAST(p0."title" AS TEXT) IN|
+
+      assert [] = Ash.read!(query)
+    end
+
+    test "empty pinned lists return no rows" do
+      assert [] =
+               Post
+               |> Ash.Query.filter(id in ^[])
+               |> Ash.read!()
+    end
+
+    test "complex list values keep the existing OR fallback" do
+      query =
+        Post
+        |> Ash.Query.new()
+        |> Ash.Query.filter(stuff in ^[%{"kind" => "one"}, %{"kind" => "two"}])
+
+      {:ok, ecto_query} = Ash.Query.data_layer_query(query)
+      {sql, _params} = Ecto.Adapters.SQL.to_sql(:all, TestRepo, ecto_query)
+
+      assert sql =~ " OR "
+      assert sql =~ ~S|json(p0."stuff")|
+      assert [] = Ash.read!(query)
+    end
+
+    test "it properly filters typed scalar values" do
+      post_id = Ash.UUID.generate()
+
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{
+          id: post_id,
+          title: "typed",
+          score: 7,
+          public: true,
+          category: "MiXeD",
+          status: :open,
+          status_enum: :closed
+        })
+        |> Ash.create!()
+
+      no_cast_post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{title: "no cast", status_enum_no_cast: :open})
+        |> Ash.create!()
+
+      integer_post =
+        IntegerPost
+        |> Ash.Changeset.for_create(:create, %{title: "integer"})
+        |> Ash.create!()
+
+      no_cast_post_id = no_cast_post.id
+      integer_post_id = integer_post.id
+
+      score_query =
+        Post
+        |> Ash.Query.filter(score in ^[7])
+
+      {:ok, ecto_query} = Ash.Query.data_layer_query(score_query)
+      {sql, _params} = Ecto.Adapters.SQL.to_sql(:all, TestRepo, ecto_query)
+
+      assert sql =~ ~s(p0."score" IN)
+      refute sql =~ ~S|CAST(p0."score" AS INTEGER) IN|
+
+      assert [%Post{id: ^post_id}] =
+               Post
+               |> Ash.Query.filter(id in ^[post_id])
+               |> Ash.read!()
+
+      assert [%Post{id: ^post_id}] =
+               Ash.read!(score_query)
+
+      assert [%Post{id: ^post_id}] =
+               Post
+               |> Ash.Query.filter(public in ^[true] and title in ^["typed"])
+               |> Ash.read!()
+
+      assert [%Post{id: ^post_id}] =
+               Post
+               |> Ash.Query.filter(category in ^["mixed"])
+               |> Ash.read!()
+
+      assert [%Post{id: ^post_id}] =
+               Post
+               |> Ash.Query.filter(status in ^[:open] and title in ^["typed"])
+               |> Ash.read!()
+
+      assert [%Post{id: ^post_id}] =
+               Post
+               |> Ash.Query.filter(status_enum in ^[:closed] and title in ^["typed"])
+               |> Ash.read!()
+
+      assert [%Post{id: ^post_id}] =
+               Post
+               |> Ash.Query.filter(created_at in ^[post.created_at] and title in ^["typed"])
+               |> Ash.read!()
+
+      assert [%Post{id: ^post_id}] =
+               Post
+               |> Ash.Query.filter(decimal in ^[Decimal.new("0")] and title in ^["typed"])
+               |> Ash.read!()
+
+      assert [%Post{id: ^no_cast_post_id}] =
+               Post
+               |> Ash.Query.filter(status_enum_no_cast in ^[:open] and title in ^["no cast"])
+               |> Ash.read!()
+
+      assert [%IntegerPost{id: ^integer_post_id}] =
+               IntegerPost
+               |> Ash.Query.filter(id in ^[integer_post_id])
                |> Ash.read!()
     end
   end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md)
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

---

This came out of a local SQLite app I’m building where I've got a route that asks for availability across a lot of media IDs, and the Ash filter is pretty ordinary:

```elixir
filter expr(media_item_id in ^arg(:media_item_ids) and best == true)
```

AshSqlite currently turns that into a long OR chain:

```sql
media_item_id = ? OR media_item_id = ? OR media_item_id = ? ...
```

That works for small lists, but not for long lists. SQLite has a max expression depth, commonly 1000 terms, which can cause the query to crash before it runs.

I used Codex to help me explore some options, and I think these queries should use SQLite’s normal scalar IN (?, ...) shape for scalar lists, and keep the existing fallback behaviour for complex values.

This PR changes that generated SQL to:

```sql
media_item_id IN (?, ?, ...)
```

That moves this case from SQLite’s expression-depth limit to SQLite’s bind-variable limit, which is around 32k depending on how SQLite is compiled. It also keeps the left-hand column uncast, which should preserve the normal indexed lookup plan.

### History

It looks like the existing OR expansion was added as a fix or workaround. See this [ash-project/ash_sqlite@83ce541](https://github.com/ash-project/ash_sqlite/commit/83ce541bca9dc0fa6458d09acd838f2b3f206b72), fix: remove list literal usage for in in ash_sqlite.

There isn’t an explanatory PR or test attached to that commit, so I’m not 100% certain for why this was implemented. My read is that AshSqlite needed to stop using the shared list-literal RHS path for SQLite, and expanding to OR was a safe local workaround because each left == value reused the existing equality/type-casting path?

This PR keeps that fallback for complex RHS values, but uses direct IN binds for scalar lists.

### Performance

I ran local comparisons to make sure the new IN shape didn’t make things worse: [here](https://gist.github.com/wtsnz/5cfcf6625625719c18be9ab2b0f6d34b) (LLM written)

The compact IN shape is faster in the tested cases, and the old OR shape fails once it hits SQLite’s expression-depth limit.

## Future

Based on feedback on my other PR there may be a better longer term shape where `ash_sql` owns the shared `in` operator flow and adapters provide capability/strategy hooks for backend-specific RHS rendering. I haven’t explored that properly yet - anyone have any instincts here?

## Validation

- `MIX_ENV=test mix test test/filter_test.exs`
- `MIX_ENV=test mix test`
- `mix format --check-formatted lib/sql_implementation.ex test/filter_test.exs`
- `git diff --check -- lib/sql_implementation.ex test/filter_test.exs`


