### PR TITLE
Handle is_distinct_from / is_not_distinct_from in the map-comparison path

### DIFF
--- a/lib/sql_implementation.ex
+++ b/lib/sql_implementation.ex
@@ -232,6 +232,64 @@ defmodule AshSqlite.SqlImplementation do
     handle_map_comparison(query, :==, left, right, pred_embedded?, bindings, embedded?, acc, type)
   end
 
+  # `is_distinct_from` is the NULL-safe form of `!=`, and Ash emits it in place of `!=` whenever
+  # either side can be nil (see `Ash.Query.Function.IsDistinctFrom.new/1`). It needs the same
+  # JSON treatment as the two clauses above, and without it a map reaches the driver as a bare
+  # Elixir term and is rejected: `(Exqlite.Error) unsupported type: %{...}`. The clearest way to
+  # see it is one resource with two `:map` attributes, where only `allow_nil?` differs - the
+  # `allow_nil? false` one takes `!=` and updates, the nullable one takes `is_distinct_from` and
+  # raises. `update_timestamp` builds exactly this comparison, so any atomic update of a nullable
+  # map attribute is affected.
+  def expr(
+        query,
+        %Ash.Query.Function.IsDistinctFrom{
+          arguments: [left, right],
+          embedded?: pred_embedded?
+        },
+        bindings,
+        embedded?,
+        acc,
+        type
+      )
+      when is_non_struct_map(left) or is_non_struct_map(right) do
+    handle_map_comparison(
+      query,
+      :is_distinct_from,
+      left,
+      right,
+      pred_embedded?,
+      bindings,
+      embedded?,
+      acc,
+      type
+    )
+  end
+
+  def expr(
+        query,
+        %Ash.Query.Function.IsNotDistinctFrom{
+          arguments: [left, right],
+          embedded?: pred_embedded?
+        },
+        bindings,
+        embedded?,
+        acc,
+        type
+      )
+      when is_non_struct_map(left) or is_non_struct_map(right) do
+    handle_map_comparison(
+      query,
+      :is_not_distinct_from,
+      left,
+      right,
+      pred_embedded?,
+      bindings,
+      embedded?,
+      acc,
+      type
+    )
+  end
+
   @impl true
   def expr(
         _query,
@@ -260,8 +318,17 @@ defmodule AshSqlite.SqlImplementation do
 
     result =
       case operator do
-        :== -> Ecto.Query.dynamic(^left_expr == ^right_expr)
-        :!= -> Ecto.Query.dynamic(^left_expr != ^right_expr)
+        :== ->
+          Ecto.Query.dynamic(^left_expr == ^right_expr)
+
+        :!= ->
+          Ecto.Query.dynamic(^left_expr != ^right_expr)
+
+        :is_distinct_from ->
+          Ecto.Query.dynamic(fragment("(? IS DISTINCT FROM ?)", ^left_expr, ^right_expr))
+
+        :is_not_distinct_from ->
+          Ecto.Query.dynamic(fragment("(? IS NOT DISTINCT FROM ?)", ^left_expr, ^right_expr))
       end
 
     {:ok, result, acc}


### PR DESCRIPTION
### The bug

An update that Ash runs atomically, on a resource with `update_timestamp(:updated_at)`, writing a
map-typed attribute that is `allow_nil? true`, fails on SQLite:

```
** (Exqlite.Error) unsupported type: %{"enabled" => "false", "v2" => "true"}
UPDATE "rag_archives" AS r0
SET "updated_at" = (CASE WHEN (? IS DISTINCT FROM r0."custom_settings")
                         THEN CAST(? AS TEXT)
                         ELSE CAST(r0."updated_at" AS TEXT) END),
    "custom_settings" = ?
WHERE ...
```

The same update against an otherwise identical attribute that is `allow_nil? false` succeeds.

### Why

`Ash.Changeset.atomic_default_condition/4` builds the "only bump the timestamp if something
actually changed" condition. If the changed attribute **can** be nil it emits
`is_distinct_from(^new_value, ^ref(key))`; if it **cannot** it emits `^new_value != ^ref(key)`.

v0.2.15 added JSON-encoded map comparison ("handle map comparisons via json encoding") to
`AshSqlite.SqlImplementation.expr/6`, but only for `Ash.Query.Operator.Eq` and
`Ash.Query.Operator.NotEq`. `Ash.Query.Function.IsDistinctFrom` has no clause, so the expression
falls through to the generic `AshSql.Expr` renderer. There,
`AshSqlite.SqlImplementation.parameterized_type/2` deliberately returns `nil` for `Ash.Type.Map`,
so `maybe_type_expr/6` produces no cast and the raw Elixir map is bound as a driver parameter.
Exqlite cannot encode a bare map and rejects it.

So `allow_nil?` is the entire discriminator, on one resource, one action, two attributes of the
same type:

| attribute | `allow_nil?` | operator Ash emits | result |
| --- | --- | --- | --- |
| `value` | `false` | `!=` | works (handled since v0.2.15) |
| `metadata` | `true` | `is_distinct_from` | `(Exqlite.Error) unsupported type` |

### Minimal repro

```elixir
defmodule Repro.Thing do
  use Ash.Resource, domain: Repro.Domain, data_layer: AshSqlite.DataLayer

  sqlite do
    table "things"
    repo Repro.Repo
  end

  attributes do
    uuid_primary_key :id
    attribute :required_map, :map, allow_nil?: false, default: %{}, public?: true
    attribute :optional_map, :map, allow_nil?: true, public?: true
    update_timestamp :updated_at          # the lazy update_default is what builds the condition
  end

  actions do
    defaults [:read, :create]
    update :update, primary?: true, accept: [:required_map, :optional_map]
  end
end

{:ok, thing} = Ash.create(Repro.Thing, %{})

# works
{:ok, _} = Ash.update(thing, %{required_map: %{"a" => 1}})

# raises: ** (Exqlite.Error) unsupported type: %{"a" => 1}
{:ok, _} = Ash.update(thing, %{optional_map: %{"a" => 1}})
```

Remove `update_timestamp :updated_at` and both succeed, because Ash never builds the condition.

### The fix

Two `expr/6` clauses for `IsDistinctFrom` / `IsNotDistinctFrom` that mirror the existing `Eq` /
`NotEq` ones exactly, routing to `handle_map_comparison/9`, plus two cases in that function
rendering `IS DISTINCT FROM` / `IS NOT DISTINCT FROM`. SQLite has supported those operators since
3.39.

The guard is the same `is_non_struct_map(left) or is_non_struct_map(right)` used by the clauses
above, so no comparison that does not involve a plain map changes behaviour.

`IS DISTINCT FROM` remains correct against the JSON encoding: the literal side becomes a JSON
string and the ref side becomes `json(col)`, and `json(NULL)` is `NULL`, so a NULL column is
correctly "distinct from" any map.

### Testing

Verified against a real application on ash 3.31.3 / ash_sqlite 0.2.17 / exqlite 0.36.0
(SQLite 3.51.3):

- 49 `(resource, update action, nullable map attribute)` triples across ~28 resources went from
  raising to executing. Each is exercised against a real database rather than verified by
  reading the code.
- Value assertions on two unrelated resources: the map is written, read back from the database and
  compared equal.
- The `allow_nil? false` control still passes, so the pre-existing `!=` branch is untouched.
- Writing `nil` still clears the column, so nil and `%{}` remain distinguishable.
- Writing the **same** map does not bump `updated_at`, which is the behaviour the condition exists
  to provide. This is the assertion that would catch a fix that simply forced the comparison true.
- Reverting the patch turns the gate red and names all 49.

### Out of scope (separate defect, reported for completeness)

`{:array, :map}` attributes are also broken on SQLite, but for a different reason and with a
different signature:

```
** (Exqlite.Error) near "[?]": syntax error
UPDATE "visual_machines" AS v0 SET ..., "connections" = ARRAY[?], "nodes" = ARRAY[?,?]
```

`AshSql.Expr.encode_list/6` renders every list literal as Postgres `ARRAY[...]` (or
`array_to_json(ARRAY[...])`) with no adapter seam. That is in `ash_sql`, affects the plain
`SET` clause as well, and is unrelated to `is_distinct_from`, so it is not addressed here. Happy
to open a separate issue on `ash_sql` if useful; it likely needs a new
`AshSql.Implementation` callback so adapters can render list literals themselves.
