### PR TITLE
Implement list_expr/6: render list literals as json_array(...)

### DIFF
--- a/lib/sql_implementation.ex
+++ b/lib/sql_implementation.ex
@@ -302,6 +302,65 @@ defmodule AshSqlite.SqlImplementation do
     :error
   end
 
+  # SQLite has no `ARRAY[...]` constructor, so the `ARRAY[...]` / `array_to_json(ARRAY[...])`
+  # rendering AshSql falls back to is a syntax error here:
+  #
+  #     ** (Exqlite.Error) near "[?,?]": syntax error
+  #     UPDATE "visual_machines" AS v0 SET ..., "nodes" = ARRAY[?,?]
+  #
+  # `json_array(...)` is the equivalent, and the element treatment is chosen to match what the
+  # data layer already stores for the same column. Ecto's SQLite adapter dumps an
+  # `{:array, :map}` field by JSON-encoding each element and then JSON-encoding the list, so the
+  # column holds a JSON array of JSON STRINGS:
+  #
+  #     ["{\"id\":\"n1\"}","{\"id\":\"n2\"}"]
+  #
+  # `json_array(?, ?)` with each parameter bound to `Jason.encode!(element)` produces exactly
+  # that, byte for byte, which is what makes the value round-trip through the loader and makes
+  # the `is_distinct_from` comparison against the column meaningful (a no-op write compares
+  # equal and does not bump `updated_at`).
+  #
+  # When the expected type is a JSON value rather than an array column (`:map` / `:json` /
+  # `:jsonb`, the case AshSql renders with `array_to_json`), the elements are JSON VALUES rather
+  # than strings, so they go through `json(...)`.
+  @impl true
+  def list_expr(query, value, bindings, embedded?, acc, type) do
+    json_value? = type in [:map, :jsonb, :json]
+
+    elements =
+      value
+      |> Enum.map(&list_element(&1, json_value?))
+      |> Enum.intersperse([raw: ","])
+      |> List.flatten()
+
+    {expr, acc} =
+      AshSql.Expr.dynamic_expr(
+        query,
+        %Ash.Query.Function.Fragment{
+          embedded?: embedded?,
+          arguments: [raw: "json_array("] ++ elements ++ [raw: ")"]
+        },
+        bindings,
+        embedded?,
+        type,
+        acc
+      )
+
+    {:ok, expr, acc}
+  end
+
+  # A plain map or list is data, and it is bound as its JSON text. Anything else (an expression,
+  # a column reference, a scalar) is rendered as itself.
+  defp list_element(item, json_value?) when is_list(item), do: encoded_element(item, json_value?)
+
+  defp list_element(item, json_value?) when is_map(item) and not is_struct(item),
+    do: encoded_element(item, json_value?)
+
+  defp list_element(item, _json_value?), do: [expr: item]
+
+  defp encoded_element(item, true), do: [raw: "json(", expr: Jason.encode!(item), raw: ")"]
+  defp encoded_element(item, false), do: [expr: Jason.encode!(item)]
+
   defp handle_map_comparison(
          query,
          operator,

--- a/mix.exs
+++ b/mix.exs
@@ -149,7 +149,7 @@ defmodule AshSqlite.MixProject do
       {:ecto, "~> 3.13"},
       {:jason, "~> 1.0"},
       {:ash, ash_version("~> 3.19")},
-      {:ash_sql, ash_sql_version("~> 0.2 and >= 0.2.20")},
+      {:ash_sql, ash_sql_version("~> 0.2 and >= 0.6.9")},
       {:igniter, "~> 0.6 and >= 0.6.14", optional: true},
       {:simple_sat, ">= 0.0.0", only: [:dev, :test]},
       {:git_ops, "~> 2.5", only: [:dev, :test]},


### PR DESCRIPTION
### Depends on

- ash-project/ash_sql#246 and its PR, which adds the `AshSql.Implementation.list_expr/6` callback
  this implements. Without that callback merged, this PR does not compile against a released
  `ash_sql`.
- Stacked on #220 (the `is_distinct_from` map comparison). The two are independent defects that
  happen to share a file; this diff applies on top of that one.

### The bug

Writing an `{:array, :map}` attribute on SQLite fails with a SQL syntax error, because
`AshSql.Expr` renders the list literal as Postgres `ARRAY[...]`:

```
** (Exqlite.Error) near "[?,?]": syntax error
UPDATE "visual_machines" AS v0 SET ..., "connections" = ARRAY[?], "nodes" = ARRAY[?,?]
```

SQLite has no array constructor, so there was nothing `AshSqlite.SqlImplementation` could do
about it until `ash_sql` grew a seam.

### The fix

`list_expr/6` renders the list as `json_array(...)`.

The element treatment is chosen to match what the data layer already stores in the same column,
which is the part worth reviewing. Ecto's SQLite adapter dumps an `{:array, :map}` field by
JSON-encoding each element and then JSON-encoding the list, so the column holds a JSON array of
JSON strings:

```
["{\"id\":\"n1\"}","{\"id\":\"n2\"}"]
```

`json_array(?, ?)`, with each parameter bound to `Jason.encode!(element)`, produces exactly that.
SQLite treats a text argument to `json_array` as a string and escapes it, which is the same
double encoding. That byte identity is what makes the value round-trip through the loader, and it
is also what makes the `is_distinct_from` comparison that `update_timestamp` builds meaningful: a
no-op write compares equal and does not bump the timestamp.

When the expected type is a JSON value rather than an array column, which is the case `AshSql`
renders with `array_to_json`, the elements are JSON values rather than strings, so they go
through `json(...)`.

Elements that are not plain maps or lists are rendered as themselves, so an expression or a
column reference inside a list still works.

### Testing

Verified against a real application on ash 3.31.3 / ash_sql 0.6.8 / ash_sqlite 0.2.17 /
exqlite 0.36.0 (SQLite 3.51.3):

- 18 `(resource, update action, `{:array, :map}` attribute)` triples across 8 resources went from
  raising to executing, each exercised against a real database.
- Value assertions: written through the update action, read back from the database, compared
  equal.
- Byte identity: a column written by an UPDATE holds the same bytes as one written by a CREATE.
- A no-op write does not bump `updated_at`; a real change does.
- Reverting this clause, so the `ash_sql` default takes over, turns the gate red and names all 18.
